### PR TITLE
gnu-debugger: Don't exec init files for test runs.

### DIFF
--- a/gnu-debugger/unix/main.rs
+++ b/gnu-debugger/unix/main.rs
@@ -171,7 +171,7 @@ fn get_exec_argv(no_python: bool) -> Vec<String> {
 }
 
 fn exec_gdb_test(mut argv: Vec<String>) -> bool {
-    argv.extend(vec!["--batch-silent".to_string()]);
+    argv.extend(vec!["--batch-silent".to_string(), "--nh".to_string()]);
 
     esp_debug_trace!("Test execution of GDB with argv: {:?}", argv);
     match Command::new(argv.get(0).unwrap())

--- a/gnu-debugger/windows/main.c
+++ b/gnu-debugger/windows/main.c
@@ -21,6 +21,7 @@
 #define GDB_EXTENSION ".exe"
 
 #define GDB_ARG_BATCH_SILENT "--batch-silent"
+#define GDB_ARG_NO_INIT "--nh"
 
 #define PYTHON_SCRIPT_CMD_OPTION " -c "
 #define PYTHON_SCRIPT_BODY "\"import sys;"\
@@ -86,7 +87,7 @@ int main (int argc, char **argv) {
 
   if (python_version) {
     // run GDB with-python to check if it executes well
-    char *test_argv[2] = { NULL, GDB_ARG_BATCH_SILENT };
+    char *test_argv[2] = { NULL, GDB_ARG_BATCH_SILENT, GDB_ARG_NO_INIT };
     if (run_gdb(python_version, 2, (const char **) test_argv, TRUE)) {
       PRINT_MESSAGE("GDB with-python test execution failed, use no-python GDB\r\n");
       free(python_version);


### PR DESCRIPTION
Hi!

I had a line in my local .gdbinit file `set debuginfod enabled on`. This triggers an error when xtensa-esp-elf-gdb starts up (it is built without debuginfod support), but is otherwise mostly harmless. However, as a result the gdb wrapper always silently fails any test gdb run and chooses the `-no-python` variant.

This commit adds the command line argument to not execute init files when testing gdb, so it doesn't matter what is in the user's gdbinit file.

I've built the unix version only, and I haven't properly tested it because the version in this repo generates a `--mcu=` argument which isn't accepted by xtensa-esp-elf-gdb v14.2_20240403. I note that the binutils repo submodule for 14.2 links to https://github.com/espressif/esp-toolchain-bin-wrappers/tree/ead71c2f7941f89fd956177049a69581fcaa48bd but this commit is not currently on GitHub.

PS It would be great if a troubleshooting tip could be added somewhere, [maybe here](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/index.html#tips-and-quirks), that mentions the existence of this wrapper and the environment variable `ESP_DEBUG_TRACE`. I figured the existence of the wrapper out from first principles using strace, instead, and then found the environment variable in the source. :laughing: 

PPS Maybe even `idf.py -v gdb` could set `ESP_DEBUG_TRACE` automatically?